### PR TITLE
Adding Cluster Scaling Documentation

### DIFF
--- a/cluster-scaling/README.adoc
+++ b/cluster-scaling/README.adoc
@@ -1,0 +1,90 @@
+= Kubernetes Cluster Scaling
+:toc:
+:imagesdir: ../images
+
+This tutorial will walk you through how to setup cluster scaling using `cluster-autoscaler` to enable worker node autoscaling based on multiple metrics within Kubernetes.
+
+== Pre-Requisites
+
+Each worker running in your Kubernetes cluster MUST have the necessary IAM Policy attached. If you previously setup your cluster using `kops` you can either modify the existing permissions on your worker IAM Role or use the following to create a new policy and attach to the IAM Role.
+
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "autoscaling:DescribeAutoScalingGroups",
+          "autoscaling:DescribeAutoScalingInstances",
+          "autoscaling:SetDesiredCapacity",
+          "autoscaling:TerminateInstanceInAutoScalingGroup"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+
+To configure these permissions you need to create the policy then attach them with the worker instance role.
+
+  $ aws iam create-policy --policy-document file://cluster-scaling/templates/asg-policy.json --policy-name ClusterAutoScaling
+  => {
+    "Policy": {
+        "PolicyName": "ClusterAutoScaling",
+        "PolicyId": "ANPAJVCFZ6I4OL6BGFGD2",
+        "Arn": "arn:aws:iam::815547143465:policy/ClusterAutoScaling",
+        "Path": "/",
+        "DefaultVersionId": "v1",
+        "AttachmentCount": 0,
+        "IsAttachable": true,
+        "CreateDate": "2017-10-05T20:35:54.964Z",
+        "UpdateDate": "2017-10-05T20:35:54.964Z"
+    }
+}
+
+
+To attach the policy to the IAM Role you first need to get the name of the role, if you setup your cluster using `kops` this will be `nodes.[DOMAIN]` such as `nodes.cluster01.kubernetes-aws.io`
+
+From the output of the `create-policy` command get the `.Policy.Arn` attribute and use that to add the policy to the role.
+
+  $ aws iam attach-role-policy --role-name nodes.cluster01.kubernetes-aws.io --policy-arn arn:aws:iam::815547143465:policy/ClusterAutoScaling
+
+
+== Deploy Worker Autoscaler
+
+This command will install the `cluster-autoscaler` with a configuration of `min: 2, max: 10, name: k8s-worker-asg`
+
+[NOTE]
+===============================
+Update the `k8s-worker-asg` to the name of your ASG in `2-10-autoscaler.yaml`
+===============================
+
+  $ kubectl apply -f cluster-scaling/templates/2-10-autoscaler.yaml
+
+Once this is deployed you can view the logs by running
+
+  $ kubectl logs deployment/cluster-autoscaler --namespace=kube-system
+
+== Validation
+
+To validate that the `cluster-autoscaler` is properly working you can use the `aws` CLI to request the current `DesiredCapacity` of your ASG with
+
+  $ aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names=$ASG_NAME | jq ".AutoScalingGroups[0].DesiredCapacity"
+  => 2
+
+Then you can deploy an application which requests more resources than your cluster has available see `cluster-scaling/templates/dummy-resource-offers.yaml` for reference.
+
+[NOTE]
+===============================
+Depending on the size of your cluster this might not trigger autoscaling. Increase the `replicas: 3` count to the necessary amount you need to fill your clusters resources.
+===============================
+
+  $ kubectl apply -f cluster-scaling/templates/dummy-resource-offers.yaml
+
+After this loads you can use the `describe-auto-scaling-groups` command again to see the `DesiredCapacity` change.
+
+  $ aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names=$ASG_NAME | jq ".AutoScalingGroups[0].DesiredCapacity"
+  => 4
+
+== Conclusion
+
+In this post we demonstrated how use `cluster-autoscaler` to dynamically scale your Kubernetes cluster based on the resource offers for the worker nodes.

--- a/cluster-scaling/templates/2-10-autoscaler.yaml
+++ b/cluster-scaling/templates/2-10-autoscaler.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+    spec:
+      containers:
+        - image: awspartners/cluster-autoscaler:v0.6.0
+          name: cluster-autoscaler
+          resources:
+            limits:
+              cpu: 100m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --nodes=2:10:nodes.kops.iamchristopherhein.com
+          env:
+            - name: AWS_REGION
+              value: us-west-2
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
+          imagePullPolicy: "Always"
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: "/etc/ssl/certs/ca-certificates.crt"

--- a/cluster-scaling/templates/asg-policy.json
+++ b/cluster-scaling/templates/asg-policy.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeAutoScalingInstances",
+        "autoscaling:SetDesiredCapacity",
+        "autoscaling:TerminateInstanceInAutoScalingGroup"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/cluster-scaling/templates/dummy-resource-offers.yaml
+++ b/cluster-scaling/templates/dummy-resource-offers.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: greeter
+spec:
+  selector:
+    app: greeter
+  ports:
+    - port: 8080
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: greeter
+  labels:
+    app: greeter
+spec:
+  replicas: 6
+  template:
+    metadata:
+      labels:
+        app: greeter
+    spec:
+      containers:
+      - name: name
+        image: arungupta/greeter-service:latest
+        resources:
+          limits:
+            cpu: 1024m
+            memory: 1024M
+          requests:
+            cpu: 500m
+            memory: 512M
+        ports:
+        - containerPort: 8080


### PR DESCRIPTION
**Why:**

* Adds documentation showing how to deploy cluster auto scaling w/ AWS

**This change addresses the need by:**

* Closes #9 

**Orginal Issue Requirements:**
- [x] Add new master and worker nodes pro-actively
  - `Master` is going to be much harder due to horizontal scaling not directly correlating to more scale. This IMO should be part of cluster upgrading, Bring up new masters with original desired state, shift traffic over shut down old cluster. **Thoughts?**
- [ ] Add new worker nodes based upon application alerts
  - I would assume this relates to HPA + Cluster Autoscaling - HPA notices app metrics causing it to scale, then the resource offers extending beyond the cluster available resources causing CA to add additional nodes. **Thoughts?**
- [x] Add new workers nodes if a certain application can be deployed because of lack of resources