### PR TITLE
updated links

### DIFF
--- a/cluster-install/README.adoc
+++ b/cluster-install/README.adoc
@@ -74,12 +74,13 @@ The Kops CLI can be used to create a highly available cluster, with multiple mas
 - Setting up AWS resources such as networks, Auto Scaling groups, IAM users, and security groups
 - Installing Kubernetes.
 
-Start the Kubernetes cluster using the following command:
+Create a Kubernetes cluster using the following command. This will create a cluster with a single master, multi node and multi-az configuration:
 
     kops create cluster \
       --name cluster01.kubernetes-aws.io \
+      --zones us-east-1d,us-east-1e \
       --state s3://kubernetes-aws-config
-    # review cluster info and make changes if necessary (for ex, subnet sizing)
+    # review cluster info and make changes if necessary (for e.g., subnet sizing)
     kops get cluster
     kops edit cluster cluster01.kubernetes-aws.io
     # update and commit
@@ -87,7 +88,7 @@ Start the Kubernetes cluster using the following command:
 
 More options for creating k8s clusters are listed below
 
-Create cluster with multi master, multi node and multi-az configuration
+Create a cluster with multi master, multi node and multi-az configuration
 
     kops create cluster \
       --name cluster02.kubernetes-aws.io \

--- a/cluster-install/dns-cluster.adoc
+++ b/cluster-install/dns-cluster.adoc
@@ -1,7 +1,7 @@
-= Install Kubernetes cluster using Kops
+= Install DNS-based Kubernetes cluster using Kops
 :toc:
 
-This tutorial will walk you through how to install Kubernetes cluster using kops.
+This tutorial will walk you through how to install a Kubernetes cluster using kops. This cluster will use DNS for node discovery and communication.
 
 https://github.com/kubernetes/kops[Kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters in the cloud. A rolling upgrade of an older version of Kubernetes to a new version can also be performed. It also manages the cluster add-ons. After the cluster is created, the usual kubectl CLI can be used to manage resources in the cluster.
 
@@ -43,7 +43,7 @@ Kops needs a “state store” to store configuration information of the cluster
 
 == Create hosted zone on Route53
 
-As of Kops 1.7.0, a top-level domain or a subdomain is required to create the cluster. This domain allows the worker nodes to discover the master and the master to discover all the etcd servers. This is also needed for kubectl to be able to talk directly with the master.
+A top-level domain or a subdomain is required to create the cluster. This domain allows the worker nodes to discover the master and the master to discover all the etcd servers. This is also needed for kubectl to be able to talk directly with the master.
 
 This domain may be registered with AWS, in which case a Route 53 hosted zone is created for you. Alternatively, this domain may be at a different registrar. In this case, create a Route 53 hosted zone. Specify the name server (NS) records from the created zone as NS records with the domain registrar.
 
@@ -74,55 +74,77 @@ The Kops CLI can be used to create a highly available cluster, with multiple mas
 - Setting up AWS resources such as networks, Auto Scaling groups, IAM users, and security groups
 - Installing Kubernetes.
 
+Below are examples of how to use kops to create different cluster configurations.
+
+=== Create a single master, multi-node, multi-az cluster
 Create a Kubernetes cluster using the following command. This will create a cluster with a single master, multi node and multi-az configuration:
 
     kops create cluster \
       --name cluster01.kubernetes-aws.io \
       --zones us-east-1d,us-east-1e \
       --state s3://kubernetes-aws-config
+
+Now build the cluster:
+
     # review cluster info and make changes if necessary (for e.g., subnet sizing)
     kops get cluster
     kops edit cluster cluster01.kubernetes-aws.io
     # update and commit
     kops update cluster cluster01.kubernetes-aws.io --yes
 
-More options for creating k8s clusters are listed below
-
-Create a cluster with multi master, multi node and multi-az configuration
+=== Create a multi-master, multi-node, multi-az cluster
+Create a cluster with multi-master, multi-node and multi-az configuration
 
     kops create cluster \
       --name cluster02.kubernetes-aws.io \
       --master-count 3 \
-      --master-zones us-east-1a,us-east-1b \
+      --master-zones us-east-1a,us-east-1b,us-east-1c \
       --node-count 5 \
       --zones us-east-1a,us-east-1b,us-east-1c \
       --state s3://kubernetes-aws-config
 
-Create cluster with Route53 private hosted zone and VPC
+Now build the cluster:
+
+    # review cluster info and make changes if necessary (for e.g., subnet sizing)
+    kops get cluster
+    kops edit cluster cluster02.kubernetes-aws.io
+    # update and commit
+    kops update cluster cluster02.kubernetes-aws.io --yes
+
+=== Create a single master, multi-node, multi-az cluster with a Route53 private hosted zone and VPC
 
     kops create cluster \
       --dns private \
       --name cluster03.k8s-aws.internal \
-      --zones us-east-1a,us-east-1b \
+      --master-zones us-east-1a,us-east-1b,us-east-1c \
+      --node-count 6 \
+      --zones us-east-1a,us-east-1b,us-east-1c \
       --state s3://kubernetes-aws-config \
       --vpc $VPCID \
       --network-cidr 10.1.0.0/16\
       --ssh-public-key $mypubkey
 
-== Validate cluster
+Now build the cluster:
+
+    # review cluster info and make changes if necessary (for e.g., subnet sizing)
+    kops get cluster
+    kops edit cluster cluster03.k8s-aws.internal
+    # update and commit
+    kops update cluster cluster03.k8s-aws.internal --yes
+
+== Validate the cluster
 
     kops validate cluster
 
-The following is the output for cluster with 3 master nodes and 6 worker nodes using Route53
-    private hosted zone
+The following is the output for cluster with 3 master nodes and 6 worker nodes using Route53 private hosted zone
 
     Using cluster from kubectl context: cluster03.k8s-aws.internal
     Validating cluster cluster03.k8s-aws.internal
     INSTANCE GROUPS
     NAME			ROLE	MACHINETYPE	MIN	MAX	SUBNETS
     master-us-east-1a-1	Master	m3.medium	1	1	us-east-1a
-    master-us-east-1a-2	Master	m3.medium	1	1	us-east-1a
     master-us-east-1b-1	Master	m3.medium	1	1	us-east-1b
+    master-us-east-1c-1	Master	m3.medium	1	1	us-east-1c
     nodes			Node	t2.medium	6	6	us-east-1a,us-east-1b,us-east-1c
 
     NODE STATUS
@@ -153,7 +175,7 @@ private hosted zone along with VPC option.
 == Delete cluster
 
     kops delete cluster \
-      cluster01.kubernetes-aws.io \
+      cluster03.k8s-aws.internal \
       --state s3://kubernetes-aws-config \
       --yes
     # Find Route53 hosted zone ID from the console or via CLI and delete hosted zone

--- a/cluster-install/dns-cluster.adoc
+++ b/cluster-install/dns-cluster.adoc
@@ -111,7 +111,7 @@ Now build the cluster:
     # update and commit
     kops update cluster cluster02.kubernetes-aws.io --yes
 
-=== Create a single master, multi-node, multi-az cluster with a Route53 private hosted zone and VPC
+=== Create a multi-master, multi-node, multi-az cluster with a Route53 private hosted zone and VPC
 
     kops create cluster \
       --dns private \
@@ -136,7 +136,7 @@ Now build the cluster:
 
     kops validate cluster
 
-The following is the output for cluster with 3 master nodes and 6 worker nodes using Route53 private hosted zone
+The following is the output for a cluster with 3 master nodes and 6 worker nodes using a Route53 private hosted zone
 
     Using cluster from kubectl context: cluster03.k8s-aws.internal
     Validating cluster cluster03.k8s-aws.internal
@@ -160,8 +160,8 @@ The following is the output for cluster with 3 master nodes and 6 worker nodes u
     ip-10-10-93-160.ec2.internal	master	True
     Your cluster cluster03.k8s-aws.internal is ready
 
-TIP: You may need to add cluster API endpoints into your hosts file (/etc/hosts) if you use Route53
-private hosted zone along with VPC option.
+TIP: You may need to add cluster API endpoints into your hosts file (/etc/hosts) if you use a Route53
+private hosted zone along with the VPC option.
 
 == Create VPC (Optional)
 

--- a/cluster-install/gossip-cluster.adoc
+++ b/cluster-install/gossip-cluster.adoc
@@ -1,0 +1,98 @@
+= Install gossip-based Kubernetes cluster using Kops
+:toc:
+
+This tutorial will walk you through how to install a Kubernetes cluster using kops. This cluster will use the gossip protocol for node discovery and communication.
+
+https://github.com/kubernetes/kops[Kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters in the cloud. A rolling upgrade of an older version of Kubernetes to a new version can also be performed. It also manages the cluster add-ons. After the cluster is created, the usual kubectl CLI can be used to manage resources in the cluster.
+
+== Install kops and kubectl
+
+There is no need to download the Kubernetes binary distribution for creating a cluster using kops. However, you do need to download the kops CLI. It then takes care of downloading the right Kubernetes binary in the cloud, and provisions the cluster.
+
+    brew update && install kops
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.goo\
+    gleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl
+    chmod +x ./kubectl
+    sudo mv ./kubectl /usr/local/bin/kubectl
+
+== IAM user permission
+
+Make sure the latest version of http://docs.aws.amazon.com/cli/latest/userguide/installing.html[AWS CLI]
+is installed. User permissions being used must have these http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html[IAM policies] attached
+
+    AmazonEC2FullAccess
+    AmazonRoute53FullAccess
+    AmazonS3FullAccess
+    IAMFullAccess
+    AmazonVPCFullAccess
+
+Please review this link for additional info on IAM permission:
+https://github.com/kubernetes/kops/blob/master/docs/aws.md#setup-iam-user
+
+== S3 bucket to store Kubernetes config
+
+Kops needs a “state store” to store configuration information of the cluster.  For example, how many nodes, instance type of each node, and Kubernetes version. The state is stored during the initial cluster creation. Any subsequent changes to the cluster are also persisted to this store as well. As of now, Amazon S3 is the only supported storage mechanism. Create a S3 bucket and pass that to the kops CLI during cluster creation.
+
+    aws s3api create-bucket --bucket kubernetes-aws-config
+    # enable versioning and export
+    aws s3api put-bucket-versioning \
+      --bucket kubernetes-aws-config 
+      --versioning-configuration\
+    Status=Enabled
+    export KOPS_STATE_STORE=s3://kubernetes-aws-config
+
+== Create kubernetes cluster
+
+The Kops CLI can be used to create a highly available cluster, with multiple master nodes spread across multiple Availability Zones. Workers can be spread across multiple zones as well. Some of the tasks that happen behind the scene during cluster creation are:
+
+- Provisioning EC2 instances
+- Setting up AWS resources such as networks, Auto Scaling groups, IAM users, and security groups
+- Installing Kubernetes.
+
+Below are examples of how to use kops to create different cluster configurations. To create a cluster using the gossip protocol, the cluster name suffix of `.k8s.local` is required.
+
+=== Create a single master, multi-node, multi-az cluster
+Create a Kubernetes cluster using the following command. This will create a cluster with a single master, multi-node and multi-az configuration. Note that `create cluster` only creates and stores the cluster config in S3; you must use `update cluster` to build the cluster:
+
+    kops create cluster \
+      --name cluster01.k8s.local \
+      --zones us-east-1d,us-east-1e \
+      --state s3://kubernetes-aws-config
+
+Now build the cluster:
+
+    # review cluster info and make changes if necessary (for ex, subnet sizing)
+    kops get cluster
+    kops edit cluster cluster01.k8s.local
+    # update and commit
+    kops update cluster cluster01.k8s.local --yes
+
+=== Create a multi-master, multi-node, multi-az cluster
+Create a cluster with multi-master, multi-node and multi-az configuration
+
+    kops create cluster \
+      --name cluster02.k8s.local \
+      --master-count 3 \
+      --master-zones us-east-1a,us-east-1b,us-east-1c \
+      --node-count 5 \
+      --zones us-east-1a,us-east-1b,us-east-1c \
+      --state s3://kubernetes-aws-config
+
+Now build the cluster:
+
+    # review cluster info and make changes if necessary (for ex, subnet sizing)
+    kops get cluster
+    kops edit cluster cluster02.k8s.local
+    # update and commit
+    kops update cluster cluster02.k8s.local --yes
+
+== Validate cluster
+
+    kops validate cluster
+
+== Delete cluster
+
+    kops delete cluster \
+      cluster01.k8s.local \
+      --state s3://kubernetes-aws-config \
+      --yes

--- a/deployment-concepts/daemonsets.adoc
+++ b/deployment-concepts/daemonsets.adoc
@@ -1,7 +1,7 @@
 = Daemon Sets
 
 == Creating a DaemonSet
-The folowing will be an example DaemonSet that runs a logstash image. Let's begin with the template:
+The following is an example of a DaemonSet that runs a logstash image. Let's begin with the template:
 
 	apiVersion: extensions/v1beta1
 	kind: DaemonSet
@@ -41,7 +41,7 @@ The folowing will be an example DaemonSet that runs a logstash image. Let's begi
 
 Run the following command to create the ReplicaSet and pods:
 
-	kubectl create -f https://github.com/arun-gupta/kubernetes-aws-workshop/blob/master/templates/daemonset.yaml --record
+	kubectl create -f https://raw.githubusercontent.com/arun-gupta/kubernetes-aws-workshop/master/deployment-concepts/templates/daemonset.yaml --record
 
 The *--record* flag will track changes made through each revision.
 
@@ -127,3 +127,8 @@ After the update is performed, we have now configured logstash to run off a spec
 	logstash-daemonset-hb365   1/1       Running       5          26m
 	logstash-daemonset-pzvkw   1/1       Terminating   0          1m
 	logstash-daemonset-t9f0n   1/1       Terminating   0          1m
+
+== Delete the DaemonSet
+Run the following command to delete the DaemonSet:
+
+	kubectl delete -f https://raw.githubusercontent.com/arun-gupta/kubernetes-aws-workshop/master/deployment-concepts/templates/daemonset.yaml

--- a/deployment-concepts/deployments.adoc
+++ b/deployment-concepts/deployments.adoc
@@ -26,7 +26,7 @@ The folowing will be an example Deployment with an nginx base image. Let's begin
 
 Run the following command to create Deployment:
 
-	kubectl create -f https://github.com/arun-gupta/kubernetes-aws-workshop/blob/master/templates/deployment.yaml --record
+	kubectl create -f https://raw.githubusercontent.com/arun-gupta/kubernetes-aws-workshop/master/deployment-concepts/templates/deployment.yaml --record
 
 The *--record* flag will track changes made through each revision.
 
@@ -103,7 +103,7 @@ If rolling back to a specific revision then enter:
 
 	kubectl rollout undo deployment/nginx-deployment --to-revision=1
 
-== Delete a deployment
-Run the following command to delete deployment:
+== Delete the Deployment
+Run the following command to delete the Deployment:
 
-	kubectl delete -f https://github.com/arun-gupta/kubernetes-aws-workshop/blob/master/templates/deployment.yaml
+	kubectl delete -f https://raw.githubusercontent.com/arun-gupta/kubernetes-aws-workshop/master/deployment-concepts/templates/deployment.yaml

--- a/deployment-concepts/readme.adoc
+++ b/deployment-concepts/readme.adoc
@@ -4,11 +4,11 @@
 Kubernetes contains a number of abstractions that map to API objects. These Kubernetes API Objects can be used to describe your cluster's desired state which will include info such as applications and workloads running, replicas, container images, networking resources and more. Below are a few examples.
 
 == Deployments
-A desired state can be described in a Deployment object. The Deployment controller changes the actaul state to the desired state. 
+A desired state can be described in a Deployment object. The Deployment controller changes the actual state to the desired state.
 https://github.com/arun-gupta/kubernetes-aws-workshop/blob/master/deployment-concepts/deployments.adoc
 
 == Replica Sets
-A RepllicaSet specifies a number of pod repliacas that can be run at any given time. The Deployment manages the ReplicaSets and provides updates to those pods. ReplicaSets can be used in lieu of Deployments if you require custom orchestration or do not need updates.
+A ReplicaSet specifies a number of pod replicas that can be run at any given time. The Deployment manages the ReplicaSets and provides updates to those pods. ReplicaSets can be used in lieu of Deployments if you require custom orchestration or do not need updates.
 https://github.com/arun-gupta/kubernetes-aws-workshop/blob/master/deployment-concepts/replicasets.adoc
 
 == Daemon Sets
@@ -16,5 +16,5 @@ DeamonSets allow the cluster of nodes to run a specified pod. As nodes are added
 https://github.com/arun-gupta/kubernetes-aws-workshop/blob/master/deployment-concepts/daemonsets.adoc
 
 == Services
-A Kubernetes service defines a logical set of pods and enables them to be access through micro-services. 
+A Kubernetes service defines a logical set of pods and enables them to be accessed through micro-services.
 https://github.com/arun-gupta/kubernetes-aws-workshop/blob/master/deployment-concepts/services.adoc

--- a/deployment-concepts/replicasets.adoc
+++ b/deployment-concepts/replicasets.adoc
@@ -26,7 +26,7 @@ The folowing will be an example ReplicaSet with an nginx base image. Let's begin
 
 Run the following command to create the ReplicaSet and pods:
 
-	kubectl create -f https://github.com/arun-gupta/kubernetes-aws-workshop/blob/master/templates/replicaset.yaml --record
+	kubectl create -f https://raw.githubusercontent.com/arun-gupta/kubernetes-aws-workshop/master/deployment-concepts/templates/replicaset.yaml --record
 
 The *--record* flag will track changes made through each revision.
 
@@ -59,3 +59,8 @@ The output should look similar the following:
 	  9m            9m              1       replicaset-controller                   Normal          SuccessfulCreate        Created pod: nginx-replicaset-z1sj6
 	  9m            9m              1       replicaset-controller                   Normal          SuccessfulCreate        Created pod: nginx-replicaset-1b05f
 	  9m            9m              1       replicaset-controller                   Normal          SuccessfulCreate        Created pod: nginx-replicaset-bftwj
+
+== Delete a ReplicaSet
+Run the following command to delete the ReplicaSet:
+
+	kubectl create -f https://raw.githubusercontent.com/arun-gupta/kubernetes-aws-workshop/master/deployment-concepts/templates/replicaset.yaml

--- a/deployment-concepts/services.adoc
+++ b/deployment-concepts/services.adoc
@@ -55,7 +55,7 @@ First deploy an app. In this example, we will create an echo app that responds w
 
 Type the following to create the deployment:
 
-	kubectl create -f https://github.com/arun-gupta/kubernetes-aws-workshop/blob/master/templates/echo.yaml --record
+	kubectl create -f https://raw.githubusercontent.com/arun-gupta/kubernetes-aws-workshop/master/deployment-concepts/templates/echo.yaml --record
 
 Type "kubectl describe deployment" to confirm demo-app has been deployed:
 
@@ -109,7 +109,7 @@ This template will expose "demo-app" to the internet by creating an outward faci
 
 Run the following command to create the service:
 
-	kubectl create -f https://github.com/arun-gupta/kubernetes-aws-workshop/blob/master/templates/service.yaml --record
+	kubectl create -f https://raw.githubusercontent.com/arun-gupta/kubernetes-aws-workshop/master/deployment-concepts/templates/service.yaml --record
 
 After describing, you should get something like the following:
 
@@ -147,3 +147,9 @@ After describing, you should get something like the following:
 	Events:                 <none>
 
 If you go to the LoadBalancer Ingress in your browser, you should hit a webpage containing the echo response.
+
+== Delete a Service
+Run the following command to delete the Service:
+
+	kubectl delete -f https://raw.githubusercontent.com/arun-gupta/kubernetes-aws-workshop/master/deployment-concepts/templates/service.yaml
+	kubectl delete -f https://raw.githubusercontent.com/arun-gupta/kubernetes-aws-workshop/master/deployment-concepts/templates/echo.yaml

--- a/getting-started/README.adoc
+++ b/getting-started/README.adoc
@@ -137,6 +137,15 @@ The last item we will take a look as is the kube dashboard which displays some b
 
 Browse around and become familiar with some the of kubernetes terminology which we will dig into deeper in the following tutorials.
 
-Let's create a Kubernetes cluster as explained in link:../cluster-install[Install Kubernetes cluster using Kops].
+== Setup Kubernetes cluster on AWS using Kops
+
+Provision a highly available Kubernetes cluster on AWS using Kops, the Kubernetes Operations tool. When setting up a cluster you have two options on how the nodes in the cluster communicate:
+
+* using the gossip protocol. A gossip-based cluster is easier to setup, so we'll use this as the default. Setup a link:../cluster-install/gossip-cluster.adoc[gossip-based cluster] here
+* using DNS. If you'd like to setup a DNS-based cluster, the instructions for this are included link:../cluster-install/dns-cluster.adoc[here]
+
+The examples in this repo should work with either option.
+
+
 
 


### PR DESCRIPTION
updated the 'kubectl create' commands as they were pointing to the web page, not the actual file

is there a reason we are using 'hostPort' in the Pod specs? We should probably remove it. In my testing, since I'm using a 2-node cluster, the deployments of nginx fail as they create 3 replicas. 

The logstash daemonset won't start - it fails with an OOM. I'll raise an issue