### PR TITLE
added targetPort

### DIFF
--- a/microservices/app.yml
+++ b/microservices/app.yml
@@ -62,6 +62,7 @@ spec:
   ports:
     - name: web
       port: 80
+      targetPort: 8080
   type: LoadBalancer
 ---
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
Needs a targetPort, otherwise it will default to port, which won't match the podspec containerPort