### PR TITLE
Fixing command so it works in zsh

### DIFF
--- a/prereqs.adoc
+++ b/prereqs.adoc
@@ -41,7 +41,7 @@ Use `eu-central-1` AWS region for this workshop. Default AWS region used by the 
 
 Different availability zones for this region can be set in the environment variable `AWS_AVAILABILITY_ZONES` using the following command:
 
-    AWS_AVAILABILITY_ZONES="$(aws --region $AWS_DEFAULT_REGION ec2 describe-availability-zones --query AvailabilityZones[].ZoneName --output text | awk -v OFS="," '$1=$1')"
+    AWS_AVAILABILITY_ZONES="$(aws --region $AWS_DEFAULT_REGION ec2 describe-availability-zones --query 'AvailabilityZones[].ZoneName' --output text | awk -v OFS="," '$1=$1')"
 
 Echo the value of the environment variable to confirm:
 


### PR DESCRIPTION
Without wrapping the query string in single quotes, ZSH isn't able to find the array and the command fails.  Updating it so that its a quoted string and still works in bash proper.