### PR TITLE
Minor fix for AWS CLI call to get worker node IAM role ARN and `aws-cli` pod creation

### DIFF
--- a/roles/readme.adoc
+++ b/roles/readme.adoc
@@ -103,7 +103,6 @@ We need the IAM Role ARN assigned to the worker nodes.  We will need this as par
     -o jsonpath='{.items[0].spec.externalID}' | \
     xargs aws ec2 describe-instances \
     --instance-id \
-    --region us-east-1 \
     --query 'Reservations[*].Instances[*].IamInstanceProfile.Arn' | \
     sed -e 's/instance-profile/role/g'
 

--- a/roles/readme.adoc
+++ b/roles/readme.adoc
@@ -211,11 +211,12 @@ Terminate the pod:
 
 Let's update the role to grant S3 permissions:
 
-  aws iam attach-role-policy --role-name MyPodRole --policy-arn arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+  $ aws iam attach-role-policy --role-name MyPodRole --policy-arn arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
 
 Recreate the pod, log into it, then try to access S3 again.  We should now be authorized!
 
-  $ kubectl create -f aws-cli-po.yaml
+  $ kubectl create -f templates/aws-cli-po.yaml
+  pod "aws-cli" created
   $ kubectl exec -it aws-cli /bin/bash
   bash-4.3# aws s3 ls
 

--- a/roles/readme.adoc
+++ b/roles/readme.adoc
@@ -217,6 +217,8 @@ Recreate the pod, log into it, then try to access S3 again.  We should now be au
 
   $ kubectl create -f templates/aws-cli-po.yaml
   pod "aws-cli" created
+                       
+
   $ kubectl exec -it aws-cli /bin/bash
   bash-4.3# aws s3 ls
 


### PR DESCRIPTION
- A proposal for the minor issue in the readme `kube2iam` (https://github.com/arun-gupta/kubernetes-aws-workshop/issues/167)
- While there, another minor fix for a `aws-cli` pod creation