### PR TITLE
Fix difference from the existing template

### DIFF
--- a/developer-concepts/readme.adoc
+++ b/developer-concepts/readme.adoc
@@ -780,6 +780,9 @@ Here is the job specification:
 	  jobTemplate:
 	    spec:
 	      template:
+	        metadata:
+	          labels:
+	            app: hello-cronpod
 	        spec:
 	          containers:
 	          - name: hello


### PR DESCRIPTION
Because I ran this tutorial with copying contents of templates from readme, this difference caused a problem to get pods by the label selector.