### PR TITLE
Fixes #491: Prometheus Operator ClusterRole missing some permissions.

### DIFF
--- a/02-path-working-with-clusters/201-cluster-monitoring/templates/prometheus/prometheus-bundle.yaml
+++ b/02-path-working-with-clusters/201-cluster-monitoring/templates/prometheus/prometheus-bundle.yaml
@@ -40,6 +40,7 @@ rules:
   - alertmanagers
   - prometheuses
   - servicemonitors
+  - prometheusrules
   verbs:
   - "*"
 - apiGroups:
@@ -55,16 +56,19 @@ rules:
 - apiGroups: [""]
   resources:
   - pods
-  verbs: ["list", "delete"]
+  verbs: ["list", "delete", "watch"]
 - apiGroups: [""]
   resources:
   - services
   - endpoints
-  verbs: ["get", "create", "update"]
+  verbs: ["get", "create", "update", "watch", "list"]
 - apiGroups: [""]
   resources:
   - nodes
   verbs: ["list", "watch"]
+- nonResourceURLs:
+  - /metrics
+  verbs: ["get"]
 - apiGroups: [""]
   resources:
   - namespaces


### PR DESCRIPTION
*Fixes #491*

*Description of changes:*

Adds missing permissions needed to get Prometheus monitoring working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.