### PR TITLE
Update 103 to include both CPU and memory limits, fixes #574

### DIFF
--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -1555,9 +1555,9 @@ Let's create a Pod with the following configuration file:
 You may have to remove a previously running Pod or Deployment before attempting to create this Pod.
 
 	$ kubectl apply -f pod.yaml
-	Error from server (Forbidden): error when creating "pod.yaml": pods "nginx-pod" is forbidden: failed quota: quota: must specify memory
+	Error from server (Forbidden): error when creating "pod.yaml": pods "nginx-pod" is forbidden: failed quota: quota: must specify cpu,memory
 
-The error message indicates that a ResourceQuota is in effect, and that the Pod must explicitly specify memory resources.
+The error message indicates that a ResourceQuota is in effect, and that the Pod must explicitly specify CPU and memory resources.
 
 Update the configuration file to:
 
@@ -1575,6 +1575,7 @@ Update the configuration file to:
 	    resources:
 	      requests:
 	        memory: "100m"
+	        cpu: "1"
 	    ports:
 	    - containerPort: 80
 
@@ -1598,15 +1599,13 @@ Get more details about the ResourceQuota:
 	Resource                Used  Hard
 	--------                ----  ----
 	configmaps              0     5
-	cpu                     400m  4
+	cpu                     1     4
 	memory                  100m  6G
 	pods                    4     12
 	replicationcontrollers  0     3
 	services                1     5
 
 Note, how CPU and memory resources have incremented values.
-
-https://github.com/kubernetes/kubernetes/issues/55433[kubernetes#55433] provide more details on how an explicit CPU resource is not needed to create a Pod with ResourceQuota.
 
 	$ kubectl delete quota/quota
 	$ kubectl delete quota/quota2


### PR DESCRIPTION
Fixes #574 

*Description of changes:*

I am going through the tutorial right now and found some discrepancies. 

1. In [Create resources with ResourceQuota](https://github.com/aws-samples/aws-workshop-for-kubernetes/tree/master/01-path-basics/103-kubernetes-concepts#create-resources-with-resourcequota) in 103, we set a ResourceQuota for both CPU and memory limit.
2. Next, we attempt to create a Pod without any limits and get an error.
    * The error is outdated.
        * It is: `failed quota: quota: must specify memory`,
        * Should be: `failed quota: quota: must specify cpu,memory`. This is fixed.
3. Next, we attempt to create a Pod with only a memory limit and we claim it works.
    * It does not, we need to specify both a memory limit and a CPU limit. This is fixed.
4. Under `Get more details about the ResourceQuota:` the output of `kubectl describe quota/quota` says `400m` in front of CPU.
    * It should be `1`. This is fixed.
5. It's explained that due to a bug in Kubernetes, we do not need to specify both a CPU and a memory limit.
    * This line: `kubernetes#55433 provide more details on how an explicit CPU resource is not needed to create a Pod with ResourceQuota.`
    * kubernetes/kubernetes#55433 appears to have been fixed. I tried on the latest AWS EKS and it needs both CPU and memory limit.
    * I have removed that line.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.